### PR TITLE
Set log level to info

### DIFF
--- a/install_kong.sh
+++ b/install_kong.sh
@@ -14,7 +14,7 @@ source ./env
     --link kong-database:kong-database \
     --link kong-ldap:kong-ldap \
     --link kong-backend:kong-backend \
-    -e "KONG_LOG_LEVEL=debug" \
+    -e "KONG_LOG_LEVEL=info" \
     -e "KONG_DATABASE=postgres" \
     -e "KONG_PG_HOST=kong-database" \
     -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \


### PR DESCRIPTION
The log level should not be debug in the production.

Besides, lua in Kong is printing some pull event every 5 second, which floods the logs which leads the log to be useless.

Set into info.